### PR TITLE
Add kibana4 container and custom elasticsearch

### DIFF
--- a/ansible/roles/elarch/files/docker-elasticsearch/Dockerfile
+++ b/ansible/roles/elarch/files/docker-elasticsearch/Dockerfile
@@ -1,0 +1,37 @@
+# Custom Dockerfile for elasticsearch, that, other than dockerfile/elasticsearch, 
+# runs elasticsearch as user.
+
+## <cacheable header>
+FROM dockerfile/java:oracle-java7
+
+MAINTAINER Konrad Feldmeier <konrad@brainbot.com>
+
+# Upgrading is not necessary
+# RUN echo "deb http://archive.ubuntu.com/ubuntu precise main universe" > /etc/apt/sources.list &&\
+#         apt-get update &&\
+#         apt-get upgrade -y &&\
+#         rm -rf /var/lib/apt/lists/*
+## </cacheable header>
+
+
+# Create elasticsearch user
+RUN groupadd --gid 1001 elasticsearch
+RUN useradd -ms /bin/bash --gid 1001 --uid 1001 elasticsearch
+RUN chown elasticsearch. /home/elasticsearch
+
+USER elasticsearch
+ENV HOME /home/elasticsearch
+
+# Install elasticsearch
+#
+RUN cd /home/elasticsearch &&\
+wget -O - https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.4.2.tar.gz | tar xzf -
+
+EXPOSE 9200
+EXPOSE 9300
+
+ENTRYPOINT ["/home/elasticsearch/elasticsearch-1.4.2/bin/elasticsearch"]
+
+# Define volume
+VOLUME ["/data", "/backup"]
+

--- a/ansible/roles/elarch/files/docker-kibana4/Dockerfile
+++ b/ansible/roles/elarch/files/docker-kibana4/Dockerfile
@@ -1,0 +1,13 @@
+# Custom Dockerfile for kibana4.
+FROM dockerfile/java:oracle-java7
+
+MAINTAINER Konrad Feldmeier <konrad@brainbot.com>
+
+RUN wget -q -O- https://download.elasticsearch.org/kibana/kibana/kibana-4.0.0-beta3.tar.gz | tar xzvf -
+
+RUN mv /data/kibana-4.0.0-beta3 /kibana
+
+# Add config file
+ADD config/kibana.yml /kibana/config/kibana.yml
+
+ENTRYPOINT ["/kibana/bin/kibana"]

--- a/ansible/roles/elarch/files/docker-kibana4/config/kibana.yml
+++ b/ansible/roles/elarch/files/docker-kibana4/config/kibana.yml
@@ -1,0 +1,41 @@
+# Kibana is served by a back end server. This controls which port to use.
+port: 5601
+
+# The host to bind the server to.
+host: "0.0.0.0"
+
+# The Elasticsearch instance to use for all your queries.
+elasticsearch: "http://elasticsearch:9200"
+
+# Kibana uses an index in Elasticsearch to store saved searches, visualizations
+# and dashboards. It will create a new index if it doesn't already exist.
+kibana_index: ".kibana"
+
+# The default application to load.
+default_app_id: "discover"
+
+# Time in seconds to wait for responses from the back end or elasticsearch.
+# Note this should always be higher than "shard_timeout".
+# This must be > 0
+request_timeout: 60
+
+# Time in milliseconds for Elasticsearch to wait for responses from shards.
+# Note this should always be lower than "request_timeout".
+# Set to 0 to disable (not recommended).
+shard_timeout: 30000
+
+# Set to false to have a complete disregard for the validity of the SSL
+# certificate.
+verify_ssl: true
+
+# Plugins that are included in the build, and no longer found in the plugins/ folder
+bundledPluginIds:
+ - plugins/dashboard/index
+ - plugins/discover/index
+ - plugins/doc/index
+ - plugins/kibana/index
+ - plugins/metric_vis/index
+ - plugins/settings/index
+ - plugins/table_vis/index
+ - plugins/vis_types/index
+ - plugins/visualize/index

--- a/ansible/roles/elarch/tasks/main.yml
+++ b/ansible/roles/elarch/tasks/main.yml
@@ -1,6 +1,37 @@
 ---
-- name: Start elastic search + kibana in docker 
+- name: Prepare building elasticsearch image
+  copy: src=../files/docker-elasticsearch dest=/tmp/docker-elasticsearch
+
+- name: Stop and remove elasticsearch instance/image
+  sudo: yes
+  shell: docker stop elasticsearch ; docker rm elasticsearch ; docker rmi local/elasticsearch:1.4.2
+  ignore_errors: true
+
+- name: Build elasticsearch image locally
+  shell: cd /tmp/docker-elasticsearch && docker build --rm -t local/elasticsearch:1.4.2
+
+- name: Deploy elasticsearch instance
   sudo: yes
   docker: 
-      image: minimum2scp/es-kibana 
-      ports: ["80:80", "9200:9200"] 
+      image: local/elasticsearch:1.4.2
+      name: elasticsearch
+      ports: "9200:9200"
+
+- name: Prepare building kibana4 image
+  copy: src=../files/docker-kibana4 dest=/tmp/docker-kibana4
+
+- name: Stop and remove elasticsearch instance/image
+  sudo: yes
+  shell: docker stop kibana4 ; docker rm kibana4 ; docker rmi local/kibana4:beta3
+  ignore_errors: true
+
+- name: Build kibana4 locally
+  sudo: yes
+  shell: cd /tmp/docker-kibana4 && docker build --rm -t local/kibana4:beta3
+
+- name: Deploy kibana4 instance
+  sudo: yes
+  docker: 
+      name: kibana4 
+      links: elasticsearch:elasticsearch
+      ports: ["80:5601"]


### PR DESCRIPTION
This adds Dockerfile's and tasks to build and deploy our own elasticsearch and kibana4 containers.

elasticsearch is link'ed into the kibana container to allow for a simpler hostname in `kibana.yml`.