### PR TITLE
Tweak for tests to work on an Archlinux Venv

### DIFF
--- a/ansible/inventory/hosts
+++ b/ansible/inventory/hosts
@@ -1,2 +1,2 @@
 [local]
-localhost ansible_connection=local
+localhost ansible_connection=local ansible_python_interpreter=python


### PR DESCRIPTION
- The reasoning is simple. By default ansible points to /usr/bin/python
  as the python interpreter. That is python3 for Archlinux. But since we
  all work in a virtualenv then python always points to the correct
  python version.