### PR TITLE
Update kibana to a recent snapshot

### DIFF
--- a/ansible/roles/elarch/files/docker-kibana4/Dockerfile
+++ b/ansible/roles/elarch/files/docker-kibana4/Dockerfile
@@ -3,9 +3,9 @@ FROM dockerfile/java:oracle-java7
 
 MAINTAINER Konrad Feldmeier <konrad@brainbot.com>
 
-RUN wget -q -O- https://download.elasticsearch.org/kibana/kibana/kibana-4.0.0-beta3.tar.gz | tar xzvf -
+RUN wget -q -O- http://download.elastic.co/kibana/kibana/kibana-4.1.0-snapshot-linux-x64.tar.gz | tar xzvf -
 
-RUN mv /data/kibana-4.0.0-beta3 /kibana
+RUN mv /data/kibana-4.1.0-snapshot-linux-x64 /kibana
 
 # Add config file
 ADD config/kibana.yml /kibana/config/kibana.yml

--- a/ansible/roles/elarch/files/docker-kibana4/config/kibana.yml
+++ b/ansible/roles/elarch/files/docker-kibana4/config/kibana.yml
@@ -5,35 +5,64 @@ port: 5601
 host: "0.0.0.0"
 
 # The Elasticsearch instance to use for all your queries.
-elasticsearch: "http://elasticsearch:9200"
+elasticsearch_url: "http://elasticsearch:9200"
+
+# preserve_elasticsearch_host true will send the hostname specified in `elasticsearch`. If you set it to false,
+# then the host you use to connect to *this* Kibana instance will be sent.
+elasticsearch_preserve_host: true
 
 # Kibana uses an index in Elasticsearch to store saved searches, visualizations
 # and dashboards. It will create a new index if it doesn't already exist.
 kibana_index: ".kibana"
 
+# If your Elasticsearch is protected with basic auth, this is the user credentials
+# used by the Kibana server to perform maintence on the kibana_index at statup. Your Kibana
+# users will still need to authenticate with Elasticsearch (which is proxied thorugh
+# the Kibana server)
+# kibana_elasticsearch_username: user
+# kibana_elasticsearch_password: pass
+
+# If your Elasticsearch requires client certificate and key
+# kibana_elasticsearch_client_crt: /path/to/your/client.crt
+# kibana_elasticsearch_client_key: /path/to/your/client.key
+
+# If you need to provide a CA certificate for your Elasticsarech instance, put
+# the path of the pem file here.
+# ca: /path/to/your/CA.pem
+
 # The default application to load.
 default_app_id: "discover"
 
-# Time in seconds to wait for responses from the back end or elasticsearch.
-# Note this should always be higher than "shard_timeout".
+# Time in milliseconds to wait for responses from the back end or elasticsearch.
 # This must be > 0
-request_timeout: 60
+request_timeout: 300000
 
 # Time in milliseconds for Elasticsearch to wait for responses from shards.
-# Note this should always be lower than "request_timeout".
-# Set to 0 to disable (not recommended).
-shard_timeout: 30000
+# Set to 0 to disable.
+shard_timeout: 0
 
 # Set to false to have a complete disregard for the validity of the SSL
 # certificate.
 verify_ssl: true
 
+# SSL for outgoing requests from the Kibana Server (PEM formatted)
+# ssl_key_file: /path/to/your/server.key
+# ssl_cert_file: /path/to/your/server.crt
+
+# Set the path to where you would like the process id file to be created.
+# pid_file: /var/run/kibana.pid
+
+# If you would like to send the log output to a file you can set the path below.
+# This will also turn off the STDOUT log output.
+# log_file: ./kibana.log
+
 # Plugins that are included in the build, and no longer found in the plugins/ folder
-bundledPluginIds:
+bundled_plugin_ids:
  - plugins/dashboard/index
  - plugins/discover/index
  - plugins/doc/index
  - plugins/kibana/index
+ - plugins/markdown_vis/index
  - plugins/metric_vis/index
  - plugins/settings/index
  - plugins/table_vis/index

--- a/ansible/roles/elarch/tasks/main.yml
+++ b/ansible/roles/elarch/tasks/main.yml
@@ -23,17 +23,17 @@
 
 - name: Stop and remove elasticsearch instance/image
   sudo: yes
-  shell: docker stop kibana4 ; docker rm kibana4 ; docker rmi local/kibana4:beta3
+  shell: docker stop kibana4 ; docker rm kibana4 ; docker rmi local/kibana4:snapshot4.10
   ignore_errors: true
 
 - name: Build kibana4 locally
   sudo: yes
-  shell: cd /tmp/docker-kibana4 && docker build --rm -t local/kibana4:beta3 .
+  shell: cd /tmp/docker-kibana4 && docker build --rm -t local/kibana4:snapshot4.10 .
 
 - name: Deploy kibana4 instance
   sudo: yes
   docker: 
-      image: local/kibana4:beta3 
+      image: local/kibana4:snapshot4.10
       name: kibana4
       links: elasticsearch:elasticsearch
       ports: ["80:5601"]


### PR DESCRIPTION
Because of CVE 2015-1427 (tackled in #60), elasticsearch has
groovy scripting now disabled and kibana failed hard. This uses a more
recent version (4.10-SNAPSHOT) of kibana and should cooperate nicer.
